### PR TITLE
Upgrading st2:3.0dev to st2:3.2dev 

### DIFF
--- a/st2packs-builder/Dockerfile
+++ b/st2packs-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackstorm/st2:3.0dev
+FROM stackstorm/st2:3.2dev
 
 ONBUILD ARG PACKS
 ONBUILD RUN : "${PACKS:?Please add '--build-arg PACKS=\"<space separated list of pack names>\"'.}"


### PR DESCRIPTION
Upgrading st2:3.0dev to st2:3.2dev to take advantage of the new 'pack dependency resolution'.