### PR TITLE
Rely on latest 3.3dev Docker image

### DIFF
--- a/st2packs-builder/Dockerfile
+++ b/st2packs-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackstorm/st2:3.2dev
+FROM stackstorm/st2:3.3dev
 
 ONBUILD ARG PACKS
 ONBUILD RUN : "${PACKS:?Please add '--build-arg PACKS=\"<space separated list of pack names>\"'.}"


### PR DESCRIPTION
Closes #18 

Update st2packs-builder helper Docker image to rely on latest `Python 3` environment with `Ubuntu Bionic` since st2 `v3.3dev`.