### PR TITLE
Bump ST2 version to current

### DIFF
--- a/st2packs-builder/Dockerfile
+++ b/st2packs-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackstorm/st2:3.5dev
+FROM stackstorm/st2:3.7
 
 ONBUILD ARG PACKS
 ONBUILD RUN : "${PACKS:?Please add '--build-arg PACKS=\"<space separated list of pack names>\"'.}"


### PR DESCRIPTION
Change the upstream ST2 version in the Dockerfile to the current ST2 release as of this date. 

closes #27 